### PR TITLE
feat: configure Yarn Berry and Jest for ESM packages

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,0 @@
-npmScopes:
-  ver-id:
-    npmRegistryServer: "https://npm.pkg.github.com"
-    npmAuthToken: "${VER_ID_GH_TOKEN}"


### PR DESCRIPTION
This PR adds support for Yarn 4 (Berry) and fixes Jest configuration to properly handle ESM-only packages like @ver-id/node-client.