### PR TITLE
feat: remove env var usage for token configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project is in active development and is definitly not production ready. If 
 ## Configuration
 
 - The `VER_ID_GH_TOKEN` environment variable is required as long as the ver.id SDK npm package is not publicly released.
-- `JWT_SECRET`: Secret key used to verify the JWT token sent by the portal.
+- By default the component uses a shared secret to verify the JWT token sent by the portal. This can be configured by providing a `jwtSecret` in the options. Alternatively, you can provide a `tokenVerification` instance in the options.
 
 To be added:
 - Authentication token for the open product API

--- a/src/AttestationRegistrationComponent.ts
+++ b/src/AttestationRegistrationComponent.ts
@@ -8,6 +8,7 @@ export interface AttestatieRegestratieComponentOptions {
   readonly attestationService?: AttestationService;
   readonly productenService?: ProductenService;
   readonly tokenVerification?: TokenVerification;
+  readonly jwtSecret?: string;
 }
 
 export class AttestatieRegestratieComponent {
@@ -30,7 +31,7 @@ export class AttestatieRegestratieComponent {
     }
 
     // Verify token
-    const verifier = this.options.tokenVerification ?? new TokenVerification();
+    const verifier = this.options.tokenVerification ?? new TokenVerification(this.options.jwtSecret || '');
     verifier.verify(request.token);
 
     // 1. Call open-product to get prodcut

--- a/src/auth/TokenVerification.ts
+++ b/src/auth/TokenVerification.ts
@@ -3,14 +3,14 @@ import * as jwt from 'jsonwebtoken';
 export class TokenVerification {
   private readonly secret: string;
 
-  constructor() {
-    this.secret = process.env.JWT_SECRET || 'secret';
+  constructor(jwtSecret: string) {
+    this.secret = jwtSecret;
+    if (!this.secret) {
+      throw new Error('JWT secret is not set');
+    }
   }
 
   verify(token: string): string | jwt.JwtPayload {
-    if (!process.env.JWT_SECRET) {
-      console.warn('Warning: JWT_SECRET is not set, using default "secret"');
-    }
     return jwt.verify(token, this.secret);
   }
 }

--- a/src/auth/test/TokenVerification.test.ts
+++ b/src/auth/test/TokenVerification.test.ts
@@ -3,15 +3,10 @@ import { TokenVerification } from '../TokenVerification';
 
 describe('TokenVerification Integration', () => {
   let verifier: TokenVerification;
-  const secret = 'secret'; // Default secret used in TokenVerification
+  const secret = 'secret';
 
   beforeEach(() => {
-    process.env.JWT_SECRET = secret;
-    verifier = new TokenVerification();
-  });
-
-  afterEach(() => {
-    delete process.env.JWT_SECRET;
+    verifier = new TokenVerification(secret);
   });
 
   it('should verify a valid token and return payload', () => {


### PR DESCRIPTION
This allows users of this package to decide how they provide secrets.

Also remove the default jwt token value so an error is thrown in case of misconfiguration. 