### PR TITLE
feat: Implement postgres for revocations

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -22,6 +22,10 @@
       "type": "build"
     },
     {
+      "name": "@types/pg",
+      "type": "build"
+    },
+    {
       "name": "@typescript-eslint/eslint-plugin",
       "version": "^8",
       "type": "build"
@@ -64,6 +68,10 @@
       "type": "build"
     },
     {
+      "name": "pg-mem",
+      "type": "build"
+    },
+    {
       "name": "projen",
       "type": "build"
     },
@@ -93,6 +101,7 @@
     },
     {
       "name": "@ver-id/node-client",
+      "version": "^0.13.0",
       "type": "runtime"
     },
     {
@@ -101,6 +110,10 @@
     },
     {
       "name": "jsonwebtoken",
+      "type": "runtime"
+    },
+    {
+      "name": "pg",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -232,13 +232,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@gemeentenijmegen/projen-project-type,@types/jest,@types/jsonwebtoken,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,projen,ts-jest,ts-node,tsx,typescript,@aws-sdk/client-dynamodb,@aws-sdk/util-dynamodb,@ver-id/node-client,dotenv,jsonwebtoken,zod"
+          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@gemeentenijmegen/projen-project-type,@types/jest,@types/jsonwebtoken,@types/node,@types/pg,eslint-import-resolver-typescript,eslint-plugin-import,jest,pg-mem,projen,ts-jest,ts-node,tsx,typescript,@aws-sdk/client-dynamodb,@aws-sdk/util-dynamodb,dotenv,jsonwebtoken,pg,zod"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @gemeentenijmegen/projen-project-type @stylistic/eslint-plugin @types/jest @types/jsonwebtoken @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser commit-and-tag-version constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit projen ts-jest ts-node tsx typescript @aws-sdk/client-dynamodb @aws-sdk/util-dynamodb @ver-id/node-client dotenv jsonwebtoken zod"
+          "exec": "yarn upgrade @gemeentenijmegen/projen-project-type @stylistic/eslint-plugin @types/jest @types/jsonwebtoken @types/node @types/pg @typescript-eslint/eslint-plugin @typescript-eslint/parser commit-and-tag-version constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit pg-mem projen ts-jest ts-node tsx typescript @aws-sdk/client-dynamodb @aws-sdk/util-dynamodb @ver-id/node-client dotenv jsonwebtoken pg zod"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -3,7 +3,7 @@ import { Transform, TypeScriptModuleResolution } from 'projen/lib/javascript';
 
 const project = new GemeenteNijmegenTsPackage({
   defaultReleaseBranch: 'main',
-  devDeps: ['@gemeentenijmegen/projen-project-type', '@types/jsonwebtoken', 'tsx'],
+  devDeps: ['@gemeentenijmegen/projen-project-type', '@types/jsonwebtoken', 'tsx', '@types/pg', 'pg-mem'],
   name: '@gemeentenijmegen/attestatie-registratie-component',
   projenrcTs: true,
   repository: 'https://github.com/GemeenteNijmegen/attestatie-registratie-component',
@@ -11,10 +11,11 @@ const project = new GemeenteNijmegenTsPackage({
   deps: [
     '@aws-sdk/client-dynamodb',
     '@aws-sdk/util-dynamodb',
-    '@ver-id/node-client',
+    '@ver-id/node-client@^0.13.0',
     'dotenv',
     'jsonwebtoken',
     'zod',
+    'pg',
   ],
   jestOptions: {
     jestConfig: {

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ARC is opgebouwd uit pluggable abstracties:
 - **Source** — Haalt data op uit een extern systeem (bijv. Open Product API)
 - **Attestation** — Vertaalt brondata naar credential-attributen
 - **Provider** — Handelt de daadwerkelijke uitgifte en intrekking af
-- **Store** — Tijdelijke opslag voor sessiestate (bijv. DynamoDB)
+- **Store** — Opslag voor sessiestate
 
 Zie [docs/architectuur.md](docs/architectuur.md) voor een volledig overzicht.
 

--- a/docs/architectuur.md
+++ b/docs/architectuur.md
@@ -27,7 +27,7 @@ ARC kent vijf kernabstracties in `src/core/`:
 | **Source** | Data ophalen uit extern systeem | `OpenProduct` — haalt producten op via de Open Product API |
 | **Attestation** | Brondata vertalen naar credential-attributen | `OpenProductStandplaatsvergunning` — vertaalt een product naar standplaatsvergunning-attributen |
 | **Provider** | Attestatie uitgeven en intrekken | `VerID` — gebruikt de Ver.ID OAuth-flow voor uitgifte |
-| **Store** | Tijdelijke sessiestate opslaan (met TTL) | `DynamoDb`, `InMemory` |
+| **Store** | Permanente sessie opslag. Gebruikt voor revocation en later voor koppeling van open product instances via UUID. | `PostgreSql`, `DynamoDb` |
 | **Session** | Sessiestate en callback-routing beheren | Intern gebruikt door ARC en providers |
 
 Elke abstractie volgt hetzelfde patroon: een abstracte basisklasse met een `options: { config }` constructor. Implementaties breiden de config-types uit met hun eigen velden.
@@ -69,7 +69,7 @@ src/
 ├── attestations/          # Attestatiemappings per bron
 │   └── openproduct/       # Mappings voor OpenProduct-data
 ├── providers/             # Providerimplementaties (VerID)
-├── adapters/              # Store-implementaties (InMemory, DynamoDB)
+├── adapters/              # Store-implementaties (PostgreSql, DynamoDb, InMemory)
 ├── schemas.ts             # Zod-schema's en types
 ├── ARC.ts                 # Orchestrator
 └── index.ts               # Barrel exports

--- a/docs/integratie.md
+++ b/docs/integratie.md
@@ -34,7 +34,7 @@ const provider = new VerID(
 
 ### 2. Store
 
-Tijdelijke opslag voor sessiestate. Records verlopen automatisch (standaard 1 uur).
+Permanente opslag voor sessies. Records verlopen standaard niet, zodat revocatie later mogelijk blijft.
 
 ```ts
 import { DynamoDb, InMemory } from '@gemeentenijmegen/attestatie-registratie-component';
@@ -42,7 +42,7 @@ import { DynamoDb, InMemory } from '@gemeentenijmegen/attestatie-registratie-com
 // Productie: DynamoDB (regio en credentials via AWS SDK defaults)
 const store = new DynamoDb({
   tableName: 'arc-sessions',
-  defaultTtlSeconds: 3600,
+  defaultTtlSeconds: 0, // 0 = oneindig
 });
 
 // Lokaal ontwikkelen: in-memory

--- a/examples/aws.ts
+++ b/examples/aws.ts
@@ -4,7 +4,7 @@
  * This example shows how Gemeente Nijmegen uses ARC with:
  * - OpenProduct as the data source
  * - Ver.ID as the attestation provider
- * - DynamoDB for ephemeral session state
+ * - DynamoDB for permanent session storage
  * - Four Lambda functions: issue, callback, status, revoke
  */
 
@@ -35,7 +35,7 @@ function createARC() {
     ),
     store: new DynamoDb({
       tableName: process.env.ARC_STATE_TABLE!,
-      defaultTtlSeconds: 3600,
+      defaultTtlSeconds: 0, // 0 = infinite
     }),
     sources: [
       new OpenProduct({

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.5.0",
+    "@types/pg": "^8.20.0",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
     "commit-and-tag-version": "^12",
@@ -39,6 +40,7 @@
     "eslint-plugin-import": "^2.32.0",
     "jest": "^30.3.0",
     "jest-junit": "^16",
+    "pg-mem": "^3.0.14",
     "projen": "^0.99.9",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
@@ -48,9 +50,10 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1014.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
-    "@ver-id/node-client": "^0.12.0",
+    "@ver-id/node-client": "^0.13.0",
     "dotenv": "^17.3.1",
     "jsonwebtoken": "^9.0.3",
+    "pg": "^8.20.0",
     "zod": "^4"
   },
   "main": "lib/index.js",

--- a/src/ARC.ts
+++ b/src/ARC.ts
@@ -95,6 +95,9 @@ export class ARC<TProvider extends Provider<any, any> = Provider> extends Base {
   }
 
   async revoke(params: RevokeParams): Promise<RevokeResult> {
+    // TODO: revoke should (also) be able to be triggered by open product id,
+    // so we can start a revoke from within open product with a button.
+    // This way, open product instances require no knowledge of ARC.
     const validated = RevokeParamsSchema.parse(params);
     await this.options.provider.revoke(validated.sessionId);
     return { sessionId: validated.sessionId };

--- a/src/adapters/DynamoDb.ts
+++ b/src/adapters/DynamoDb.ts
@@ -28,11 +28,11 @@ export class DynamoDb extends Store<DynamoDbConfig> {
 
   async put(id: string, payload: Record<string, string>, options?: { ttlSeconds?: number }): Promise<void> {
     const ttl = options?.ttlSeconds ?? this.defaultTtlSeconds;
-    const expiresAt = Math.floor(Date.now() / 1000) + ttl;
+    const expiresAt = ttl === 0 ? undefined : Math.floor(Date.now() / 1000) + ttl;
 
     const item = marshall({
       [this.partitionKey]: id,
-      [this.ttlAttribute]: expiresAt,
+      ...(expiresAt ? { [this.ttlAttribute]: expiresAt } : {}),
       ...payload,
     });
 

--- a/src/adapters/InMemory.ts
+++ b/src/adapters/InMemory.ts
@@ -19,7 +19,7 @@ export class InMemory extends Store<InMemoryConfig> {
     const ttl = options?.ttlSeconds ?? this.defaultTtlSeconds;
     this.data.set(id, {
       payload,
-      expiresAt: Date.now() + ttl * 1000,
+      expiresAt: ttl === 0 ? Infinity : Date.now() + ttl * 1000,
     });
   }
 

--- a/src/adapters/PostgreSql.ts
+++ b/src/adapters/PostgreSql.ts
@@ -1,0 +1,92 @@
+import { Pool } from 'pg';
+import { Store, StoreConfig } from '../core/Store';
+import { StoreExpiredError, StoreNotFoundError } from '../errors';
+
+export interface PostgreSqlConfig extends StoreConfig {
+  /**
+   * PostgreSQL pool instance
+   */
+  pool: Pool;
+  /**
+   * Name of the table to use for storage (default: arc_store)
+   */
+  tableName?: string;
+}
+
+/**
+ * PostgreSQL adapter for ARC session storage.
+ *
+ * Expects a table with the following schema (created automatically during init):
+ * CREATE TABLE IF NOT EXISTS arc_store (
+ *   id TEXT PRIMARY KEY,
+ *   payload JSONB NOT NULL,
+ *   expires_at TIMESTAMP
+ * );
+ */
+export class PostgreSql extends Store<PostgreSqlConfig> {
+  private tableName: string;
+  private initialized: Promise<void>;
+
+  constructor(config: PostgreSqlConfig) {
+    super({ config });
+    this.tableName = config.tableName ?? 'arc_store';
+    this.initialized = this.initTable();
+  }
+
+  /**
+   * Initializes the database table if it doesn't exist.
+   */
+  private async initTable(): Promise<void> {
+    try {
+      await this.options.config.pool.query(`
+        CREATE TABLE IF NOT EXISTS ${this.tableName} (
+          id TEXT PRIMARY KEY,
+          payload JSONB NOT NULL,
+          expires_at TIMESTAMP
+        )
+      `);
+    } catch (error) {
+      console.error(`Failed to initialize PostgreSQL table ${this.tableName}:`, error);
+      throw error;
+    }
+  }
+
+  async put(id: string, payload: Record<string, string>, options?: { ttlSeconds?: number }): Promise<void> {
+    await this.initialized;
+    const ttl = options?.ttlSeconds ?? this.defaultTtlSeconds;
+    const expiresAt = ttl > 0 ? new Date(Date.now() + ttl * 1000) : null;
+
+    await this.options.config.pool.query(`
+      INSERT INTO ${this.tableName} (id, payload, expires_at)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (id) DO UPDATE SET
+        payload = EXCLUDED.payload,
+        expires_at = EXCLUDED.expires_at
+    `, [id, JSON.stringify(payload), expiresAt]);
+  }
+
+  async get(id: string): Promise<Record<string, string>> {
+    await this.initialized;
+    const result = await this.options.config.pool.query(`
+      SELECT payload, expires_at FROM ${this.tableName} WHERE id = $1
+    `, [id]);
+
+    if (result.rows.length === 0) {
+      throw new StoreNotFoundError(id);
+    }
+
+    const { payload, expires_at } = result.rows[0];
+
+    if (expires_at && new Date() > expires_at) {
+      await this.delete(id);
+      throw new StoreExpiredError(id);
+    }
+
+    return payload;
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.initialized;
+    await this.options.config.pool.query(`DELETE FROM ${this.tableName} WHERE id = $1`, [id]);
+  }
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -2,3 +2,5 @@ export { InMemory } from './InMemory';
 export type { InMemoryConfig } from './InMemory';
 export { DynamoDb } from './DynamoDb';
 export type { DynamoDbConfig } from './DynamoDb';
+export { PostgreSql } from './PostgreSql';
+export type { PostgreSqlConfig } from './PostgreSql';

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -12,7 +12,7 @@ export interface SessionOptions {
 }
 
 export class Session {
-  constructor(private readonly options: SessionOptions) {}
+  constructor(private readonly options: SessionOptions) { }
 
   async save(sessionId: string, context: SessionContext): Promise<void> {
     await this.options.store.put(sessionId, {
@@ -29,14 +29,6 @@ export class Session {
       id: record.id ?? '',
       attestation: record.attestation ?? '',
     };
-  }
-
-  async delete(sessionId: string): Promise<void> {
-    try {
-      await this.options.store.delete(sessionId);
-    } catch {
-      // Store record may have already expired via TTL
-    }
   }
 
   async saveCallback(state: string, sessionId: string, context: SessionContext): Promise<void> {
@@ -74,12 +66,12 @@ export class Session {
     try {
       await this.options.store.delete(`callback:${state}`);
     } catch {
-      // Store record may have already expired via TTL
+      // Store record may have already been deleted
     }
   }
 
-  async cleanupCallback(state: string, sessionId: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async cleanupCallback(state: string, _sessionId: string): Promise<void> {
     await this.deleteCallback(state);
-    await this.delete(sessionId);
   }
 }

--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -14,7 +14,7 @@ export abstract class Store<TConfig extends StoreConfig = StoreConfig> extends B
   }
 
   protected get defaultTtlSeconds(): number {
-    return this.options.config.defaultTtlSeconds ?? 3600;
+    return this.options.config.defaultTtlSeconds ?? 0;
   }
 
   abstract put(id: string, payload: Record<string, string>, options?: { ttlSeconds?: number }): Promise<void>;

--- a/test/adapters/DynamoDb.test.ts
+++ b/test/adapters/DynamoDb.test.ts
@@ -1,0 +1,115 @@
+import {
+  DynamoDBClient,
+  PutItemCommand,
+  GetItemCommand,
+  DeleteItemCommand,
+} from '@aws-sdk/client-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import { DynamoDb } from '../../src/adapters/DynamoDb';
+import { StoreNotFoundError } from '../../src/errors';
+
+jest.mock('@aws-sdk/client-dynamodb', () => {
+  return {
+    DynamoDBClient: jest.fn(),
+    PutItemCommand: jest.fn().mockImplementation((input) => ({ input })),
+    GetItemCommand: jest.fn().mockImplementation((input) => ({ input })),
+    DeleteItemCommand: jest.fn().mockImplementation((input) => ({ input })),
+  };
+});
+jest.mock('@aws-sdk/util-dynamodb');
+
+describe('DynamoDb Adapter', () => {
+  let adapter: DynamoDb;
+  let mockSend: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockSend = jest.fn();
+    (DynamoDBClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }));
+    (PutItemCommand as jest.Mock).mockImplementation((input) => ({ input }));
+    (GetItemCommand as jest.Mock).mockImplementation((input) => ({ input }));
+    (DeleteItemCommand as jest.Mock).mockImplementation((input) => ({ input }));
+
+    adapter = new DynamoDb({
+      tableName: 'test-table',
+      partitionKey: 'id',
+    });
+  });
+
+  describe('put', () => {
+    it('should store a record', async () => {
+      const id = 'test-id';
+      const payload = { foo: 'bar' };
+      const marshalledItem = { id: { S: id }, foo: { S: 'bar' } };
+
+      (marshall as jest.Mock).mockReturnValue(marshalledItem);
+
+      await adapter.put(id, payload);
+
+      expect(marshall).toHaveBeenCalledWith({
+        id,
+        ttl: expect.any(Number),
+        ...payload,
+      });
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const command = mockSend.mock.calls[0][0];
+      expect(command.input).toEqual({
+        TableName: 'test-table',
+        Item: marshalledItem,
+      });
+    });
+  });
+
+  describe('get', () => {
+    it('should retrieve and unmarshall a record', async () => {
+      const id = 'test-id';
+      const marshalledKey = { id: { S: id } };
+      const marshalledItem = { id: { S: id }, foo: { S: 'bar' } };
+      const unmarshalledItem = { id, foo: 'bar' };
+
+      (marshall as jest.Mock).mockReturnValue(marshalledKey);
+      mockSend.mockResolvedValue({ Item: marshalledItem });
+      (unmarshall as jest.Mock).mockReturnValue(unmarshalledItem);
+
+      const result = await adapter.get(id);
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const command = mockSend.mock.calls[0][0];
+      expect(command.input).toEqual({
+        TableName: 'test-table',
+        Key: marshalledKey,
+      });
+
+      expect(unmarshall).toHaveBeenCalledWith(marshalledItem);
+      expect(result).toEqual({ foo: 'bar' }); // internal attributes should be removed
+    });
+
+    it('should throw StoreNotFoundError if item is not found', async () => {
+      const id = 'missing-id';
+      mockSend.mockResolvedValue({ Item: undefined });
+
+      await expect(adapter.get(id)).rejects.toThrow(StoreNotFoundError);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a record', async () => {
+      const id = 'test-id';
+      const marshalledKey = { id: { S: id } };
+      (marshall as jest.Mock).mockReturnValue(marshalledKey);
+      mockSend.mockResolvedValue({});
+
+      await adapter.delete(id);
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const command = mockSend.mock.calls[0][0];
+      expect(command.input).toEqual({
+        TableName: 'test-table',
+        Key: marshalledKey,
+      });
+    });
+  });
+});

--- a/test/adapters/DynamoDb.test.ts
+++ b/test/adapters/DynamoDb.test.ts
@@ -39,7 +39,7 @@ describe('DynamoDb Adapter', () => {
   });
 
   describe('put', () => {
-    it('should store a record', async () => {
+    it('should store a record without TTL by default', async () => {
       const id = 'test-id';
       const payload = { foo: 'bar' };
       const marshalledItem = { id: { S: id }, foo: { S: 'bar' } };
@@ -50,15 +50,21 @@ describe('DynamoDb Adapter', () => {
 
       expect(marshall).toHaveBeenCalledWith({
         id,
-        ttl: expect.any(Number),
         ...payload,
       });
 
       expect(mockSend).toHaveBeenCalledTimes(1);
-      const command = mockSend.mock.calls[0][0];
-      expect(command.input).toEqual({
-        TableName: 'test-table',
-        Item: marshalledItem,
+    });
+
+    it('should store a record with TTL when specified', async () => {
+      const id = 'test-id';
+      const payload = { foo: 'bar' };
+      await adapter.put(id, payload, { ttlSeconds: 3600 });
+
+      expect(marshall).toHaveBeenCalledWith({
+        id,
+        ttl: expect.any(Number),
+        ...payload,
       });
     });
   });

--- a/test/adapters/InMemory.test.ts
+++ b/test/adapters/InMemory.test.ts
@@ -41,9 +41,16 @@ describe('InMemory', () => {
   });
 
   describe('TTL', () => {
-    it('should use default TTL of 3600 seconds', () => {
+    it('should use default TTL of 0 (infinite)', async () => {
       const defaultStore = new InMemory();
-      expect(defaultStore).toBeDefined();
+      await defaultStore.put('key-1', { foo: 'bar' });
+
+      jest.useFakeTimers();
+      jest.advanceTimersByTime(1000 * 60 * 60 * 24 * 365); // 1 year
+
+      const result = await defaultStore.get('key-1');
+      expect(result).toEqual({ foo: 'bar' });
+      jest.useRealTimers();
     });
 
     it('should accept custom TTL', () => {

--- a/test/adapters/PostgreSql.test.ts
+++ b/test/adapters/PostgreSql.test.ts
@@ -1,0 +1,109 @@
+import { newDb } from 'pg-mem';
+import { PostgreSql } from '../../src/adapters/PostgreSql';
+import { Session } from '../../src/core/Session';
+import { StoreExpiredError, StoreNotFoundError } from '../../src/errors';
+import { overlijdensakteContext, standplaatsvergunningContext } from '../fixtures/sessions';
+
+describe('PostgreSql Adapter', () => {
+  let adapter: PostgreSql;
+  let pool: any;
+
+  beforeEach(async () => {
+    const db = newDb();
+    // pg-mem supports JSONB and most PG features
+    const { Pool } = db.adapters.createPg();
+    pool = new Pool();
+    adapter = new PostgreSql({ pool });
+  });
+
+  afterEach(async () => {
+    await pool.end();
+  });
+
+  it('should store and retrieve data', async () => {
+    const id = 'test-id';
+    const payload = standplaatsvergunningContext as any;
+
+    await adapter.put(id, payload);
+    const retrieved = await adapter.get(id);
+
+    expect(retrieved).toEqual(payload);
+  });
+
+  it('should handle updates (upsert)', async () => {
+    const id = 'test-id';
+    await adapter.put(id, { version: '1' });
+    await adapter.put(id, { version: '2' });
+
+    const retrieved = await adapter.get(id);
+    expect(retrieved).toEqual({ version: '2' });
+  });
+
+  it('should throw StoreNotFoundError for missing records', async () => {
+    await expect(adapter.get('non-existent')).rejects.toThrow(StoreNotFoundError);
+  });
+
+  it('should delete records', async () => {
+    const id = 'test-delete';
+    await adapter.put(id, standplaatsvergunningContext as any);
+    await adapter.delete(id);
+
+    await expect(adapter.get(id)).rejects.toThrow(StoreNotFoundError);
+  });
+
+  it('should store expires_at in the database', async () => {
+    const id = 'test-schema';
+    const payload = standplaatsvergunningContext as any;
+    await adapter.put(id, payload, { ttlSeconds: 3600 });
+
+    const result = await pool.query('SELECT expires_at FROM arc_store WHERE id = $1', [id]);
+    expect(result.rows[0].expires_at).toBeInstanceOf(Date);
+  });
+
+  it('should handle TTL and expiration', async () => {
+    const id = 'test-ttl';
+    const payload = standplaatsvergunningContext as any;
+
+    // Set TTL to 1 second
+    await adapter.put(id, payload, { ttlSeconds: 1 });
+
+    // Should still be there immediately
+    expect(await adapter.get(id)).toEqual(payload);
+
+    // Manually update expires_at to the past to simulate expiration
+    await pool.query(`UPDATE ${adapter.tableName} SET expires_at = $1 WHERE id = $2`, [new Date(Date.now() - 1000), id]);
+
+    await expect(adapter.get(id)).rejects.toThrow(StoreExpiredError);
+  });
+
+  describe('Integration with Session', () => {
+    let session: Session;
+
+    beforeEach(() => {
+      session = new Session({ store: adapter });
+    });
+
+    it('should work with UUID session IDs and realistic payloads', async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440000';
+      const context = overlijdensakteContext;
+
+      await session.save(sessionId, context);
+      const retrieved = await session.get(sessionId);
+
+      expect(retrieved).toEqual(context);
+    });
+
+    it('should handle callback states with UUIDs', async () => {
+      const state = 'f81d4fae-7dec-11d0-a765-00a0c91e6bf6';
+      const sessionId = '550e8400-e29b-41d4-a716-446655440000';
+      const context = standplaatsvergunningContext;
+
+      await session.saveCallback(state, sessionId, context);
+      const retrieved = await session.getCallback(state);
+
+      expect(retrieved.sessionId).toBe(sessionId);
+      expect(retrieved.context).toEqual(context);
+    });
+  });
+
+});

--- a/test/adapters/Revocation.test.ts
+++ b/test/adapters/Revocation.test.ts
@@ -1,0 +1,74 @@
+import { InMemory } from '../../src/adapters/InMemory';
+import { ARC } from '../../src/ARC';
+import { OpenProductStandplaatsvergunning } from '../../src/attestations/openproduct/OpenProductStandplaatsvergunning';
+import { Product } from '../../src/sources/OpenProduct';
+import { validProduct } from '../fixtures/products';
+import { MockProvider } from '../mocks/MockProvider';
+import { MockSource } from '../mocks/MockSource';
+
+describe('Revocation Flow', () => {
+  let source: MockSource<Product>;
+  let provider: MockProvider;
+  let store: InMemory;
+
+  function createARC() {
+    return new ARC({
+      provider,
+      store,
+      sources: [source],
+      attestations: [new OpenProductStandplaatsvergunning()],
+    });
+  }
+
+  beforeEach(() => {
+    source = new MockSource<Product>('openproduct');
+    source.addData(validProduct.uuid, validProduct);
+    provider = new MockProvider();
+    store = new InMemory();
+  });
+
+  it('should store the session permanently during issuance and allow revocation', async () => {
+    const arc = createARC();
+
+    // 1. Issue an attestation
+    const issueResult = await arc.issue({
+      source: 'openproduct',
+      id: validProduct.uuid,
+    });
+
+    const sessionId = issueResult.sessionId;
+    expect(sessionId).toBe('mock-session-id');
+
+    // 2. Verify it's in the store
+    const sessionRecord = await store.get(sessionId);
+    expect(sessionRecord.source).toBe('openproduct');
+    expect(sessionRecord.id).toBe(validProduct.uuid);
+
+    // 3. Revoke using the sessionId
+    const revokeResult = await arc.revoke({
+      sessionId,
+    });
+
+    expect(revokeResult.sessionId).toBe(sessionId);
+    expect(provider.revokeCalls).toContainEqual({ sessionId });
+  });
+
+  it('should allow revocation even if the session was created long ago (simulated)', async () => {
+    const arc = createARC();
+
+    // 1. Issue
+    const issueResult = await arc.issue({
+      source: 'openproduct',
+      id: validProduct.uuid,
+    });
+
+    // 2. Simulate time passing (InMemory store uses Infinity for ttl: 0, so it should stay)
+    // We don't actually need to wait, but we can verify it's still there
+    const record = await store.get(issueResult.sessionId);
+    expect(record).toBeDefined();
+
+    // 3. Revoke
+    await arc.revoke({ sessionId: issueResult.sessionId });
+    expect(provider.revokeCalls).toHaveLength(1);
+  });
+});

--- a/test/core/Session.test.ts
+++ b/test/core/Session.test.ts
@@ -20,18 +20,6 @@ describe('Session', () => {
     });
   });
 
-  describe('delete', () => {
-    it('should remove a session', async () => {
-      await session.save('session-1', standplaatsvergunningContext);
-      await session.delete('session-1');
-
-      await expect(store.get('session-1')).rejects.toThrow();
-    });
-
-    it('should not throw when session does not exist', async () => {
-      await expect(session.delete('nonexistent')).resolves.toBeUndefined();
-    });
-  });
 
   describe('saveCallback and getCallback', () => {
     it('should store and retrieve callback state', async () => {
@@ -66,14 +54,14 @@ describe('Session', () => {
   });
 
   describe('cleanupCallback', () => {
-    it('should remove both callback state and session', async () => {
+    it('should remove callback state but keep session', async () => {
       await session.save('session-1', standplaatsvergunningContext);
       await session.saveCallback('state-abc', 'session-1', standplaatsvergunningContext);
 
       await session.cleanupCallback('state-abc', 'session-1');
 
       await expect(store.get('callback:state-abc')).rejects.toThrow();
-      await expect(store.get('session-1')).rejects.toThrow();
+      await expect(store.get('session-1')).resolves.toEqual(standplaatsvergunningContext);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,6 +1908,15 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
 
+"@types/pg@^8.20.0":
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.20.0.tgz#8bd03d3ac6b19143a8de7d66a9d13da32cd91526"
+  integrity sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
 "@types/stack-utils@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
@@ -2123,10 +2132,10 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
-"@ver-id/node-client@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@ver-id/node-client/-/node-client-0.12.0.tgz#c5aa926a6d31c28a9a9c827cace19cb8121be5ba"
-  integrity sha512-PJWCX3BF7TqkhA4plILlJ8eS92GKslDm/lBJr5BUPMZllf+khV4DpLeCRmRm1ba7M+N7zSU1vgY56YEVaFaQ2w==
+"@ver-id/node-client@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@ver-id/node-client/-/node-client-0.13.0.tgz#4e13d21666a948c92e7fa0280a394a46979b15fe"
+  integrity sha512-PVNpkDiB6WzMLS1R6eriAJ+CoKvPoVeuPM2Kefb2YBer4kNcZdf5zHvy+QVyd+XyIvSfldtarWIJQTqRkdUU0Q==
 
 JSONStream@^1.3.5:
   version "1.3.5"
@@ -2617,6 +2626,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@^2.19.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 comment-json@4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/comment-json/-/comment-json-4.2.2.tgz#5fae70a94e0c8f84a077bd31df5aa5269252f293"
@@ -2962,6 +2976,11 @@ diff@^4.0.1:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.4.tgz#7a6dbfda325f25f07517e9b518f897c08332e07d"
   integrity sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==
+
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -3589,6 +3608,11 @@ function.prototype.name@^1.1.6, function.prototype.name@^1.1.8:
     hasown "^2.0.2"
     is-callable "^1.2.7"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
+
 functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
@@ -3870,6 +3894,11 @@ ignore@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
+
+immutable@^4.3.4:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.8.tgz#02d183c7727fb2bb1d5d0380da0d779dce9296a7"
+  integrity sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==
 
 import-fresh@^3.2.1:
   version "3.3.1"
@@ -4652,6 +4681,17 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json-stable-stringify@^1.0.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz#8903cfac42ea1a0f97f35d63a4ce0518f0cc6a70"
+  integrity sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    isarray "^2.0.5"
+    jsonify "^0.0.1"
+    object-keys "^1.1.1"
+
 json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -4668,6 +4708,11 @@ json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -4992,6 +5037,16 @@ modify-values@^1.0.1:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+moment@^2.27.0:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
+moo@^0.5.0, moo@^0.5.1:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.3.tgz#dfcdb40ff6f1a03c34af5df7f9717cecfa88c38c"
+  integrity sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==
+
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -5006,6 +5061,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+nearley@^2.19.5:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 neo-async@^2.6.2:
   version "2.6.2"
@@ -5065,6 +5130,11 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+object-hash@^2.0.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
 object-inspect@^1.13.3, object-inspect@^1.13.4:
   version "1.13.4"
@@ -5310,6 +5380,83 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+pg-cloudflare@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz#386035d4bfcf1a7045b026f8b21acf5353f14d65"
+  integrity sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==
+
+pg-connection-string@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.12.0.tgz#4084f917902bb2daae3dc1376fe24ac7b4eaccf2"
+  integrity sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-mem@^3.0.14:
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/pg-mem/-/pg-mem-3.0.14.tgz#cf3a2e7b2ec929afade4672d62535daef1c839b8"
+  integrity sha512-G9m8OD0A+YS083smidSUJddTX2dEDPT8mRMG3sQGNiGfS/mkvAgd9Kf1/onD5633bFN7HcQK/Tn2x7qjBMFRUQ==
+  dependencies:
+    functional-red-black-tree "^1.0.1"
+    immutable "^4.3.4"
+    json-stable-stringify "^1.0.1"
+    lru-cache "^6.0.0"
+    moment "^2.27.0"
+    object-hash "^2.0.3"
+    pgsql-ast-parser "^12.0.2"
+
+pg-pool@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.13.0.tgz#416482e9700e8f80c685a6ae5681697a413c13a3"
+  integrity sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==
+
+pg-protocol@*, pg-protocol@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.13.0.tgz#fdaf6d020bca590d58bb991b4b16fc448efe0511"
+  integrity sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==
+
+pg-types@2.2.0, pg-types@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@^8.20.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.20.0.tgz#1a274de944cb329fd6dd77a6d371a005ba6b136d"
+  integrity sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==
+  dependencies:
+    pg-connection-string "^2.12.0"
+    pg-pool "^3.13.0"
+    pg-protocol "^1.13.0"
+    pg-types "2.2.0"
+    pgpass "1.0.5"
+  optionalDependencies:
+    pg-cloudflare "^1.3.0"
+
+pgpass@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
+  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+  dependencies:
+    split2 "^4.1.0"
+
+pgsql-ast-parser@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/pgsql-ast-parser/-/pgsql-ast-parser-12.0.2.tgz#b69a7c10b8078a7413c2d660fae0500543a0d080"
+  integrity sha512-1WWa96Sw6h4uv9GLw98EzH/+xoBTC8j2TwV/AMW3E+Ir/fHOu/jLLbj6kPiz3y2bGISTKNYvKWwHoqvQ5FLuAw==
+  dependencies:
+    moo "^0.5.1"
+    nearley "^2.19.5"
+
 picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -5351,6 +5498,28 @@ possible-typed-array-names@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz#c40b3da0222c500ff1e51c5d7014b60b79697c7a"
+  integrity sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -5419,6 +5588,19 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 react-is@^18.3.1:
   version "18.3.1"
@@ -5564,6 +5746,11 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@^1.22.4:
     is-core-module "^2.16.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
 reusify@^1.0.4:
   version "1.1.0"
@@ -5803,6 +5990,11 @@ split2@^3.2.2:
   integrity sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==
   dependencies:
     readable-stream "^3.0.0"
+
+split2@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
 
 split@^1.0.1:
   version "1.0.1"
@@ -6449,7 +6641,7 @@ xmlbuilder2@^4.0.3:
     "@oozcitak/util" "^10.0.0"
     js-yaml "^4.1.1"
 
-xtend@~4.0.1:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
tbd:
- the store isn't just for temp storage anymore. Perhaps we should remove the ttl? Or use it to set the expiration based on the end date of a product instance
- in memory is for development only, it's not persistent. Perhaps we should remove it or add a warning.
- the postgres store used a schemaless payload. It would prevent bugs if we defined all fields that we want to store in the schema definition.